### PR TITLE
add browse function, update to supported APIs, remove default key mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,16 @@
 
 - [Chrome Webstore](https://chrome.google.com/webstore/detail/oofoadncochbkbpebpbndghocapamchi)
 
-## Liscence
+## License
+
 MIT © [Daniel Pham](https://danhp.github.io)
+
+## Changelog
+
+1.0.1
+- Added active/select browsing tab functionality
+- Removed default key suggestions so that [this](https://bugs.chromium.org/p/chromium/issues/detail?id=167419) bug is not hit now or in the future
+- Updated API usage to query() from getSelected() since this has been deprecated since Chrome 33
+
+1.0.0
+- Initial Release

--- a/src/background.js
+++ b/src/background.js
@@ -1,10 +1,12 @@
 chrome.commands.onCommand.addListener(function(command) {
     var newIndex;
+    var maxTabIndex = 0;
 
     switch (command) {
+        // pinning
         case 'tab_manager_pin_current':
-            chrome.tabs.getSelected(null, function(tab){
-                chrome.tabs.update(tab.id, {pinned: !tab.pinned});
+            chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tab) {
+                chrome.tabs.update(tab[0].id, {pinned: !tab[0].pinned});
             });
             break;
 
@@ -16,19 +18,63 @@ chrome.commands.onCommand.addListener(function(command) {
             });
             break;
 
+        // moving
         case "tab_manager_move_left":
-            chrome.tabs.getSelected(null, function(tab) {
-                newIndex = tab.index - 1;
+            chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tab) {
+                newIndex = tab[0].index - 1;
                 if (newIndex < 0) return;
-                chrome.tabs.move(tab.id, {index: newIndex});
+                chrome.tabs.move(tab[0].id, {index: newIndex});
             });
             break;
 
         case "tab_manager_move_right":
-            chrome.tabs.getSelected(null, function(tab) {
-                newIndex = tab.index + 1;
+            chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tab) {
+                newIndex = tab[0].index + 1;
                 if (newIndex < 0) return;
-                chrome.tabs.move(tab.id, {index: newIndex});
+                chrome.tabs.move(tab[0].id, {index: newIndex});
+            });
+            break;
+
+        // browsing
+        case "tab_manager_browse_left":
+            chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tab) {
+                newIndex = tab[0].index - 1;
+                if (newIndex >= 0) {
+                    chrome.tabs.query({index: newIndex}, function(btab) {
+                        chrome.tabs.update(btab[0].id, {active: true});
+                    });
+                } else {
+                    // first tab reached
+                    chrome.tabs.query({}, function (maxTab) {
+                        maxTab.forEach(function (t) {
+                            // find the maximum tab index (0-based)
+                            if (t.index > maxTabIndex) {
+                                maxTabIndex = t.index;
+                            }
+                        });
+                        // update the maximum tab index to be active
+                        chrome.tabs.query({index: maxTabIndex}, function(tabMax) {
+                            chrome.tabs.update(tabMax[0].id, {active: true});
+                        });
+                        maxTabIndex = 0;
+                    });
+                }
+            });
+            break;
+
+        case "tab_manager_browse_right":
+            chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tab) {
+                newIndex = tab[0].index + 1;
+                chrome.tabs.query({index: newIndex}, function(btab) {
+                    if (btab.length > 0) {
+                       chrome.tabs.update(btab[0].id, {active: true});
+                    } else {
+                        // last tab reached, go back to first (0-based)
+                        chrome.tabs.query({index: 0}, function(tab0) {
+                          chrome.tabs.update(tab0[0].id, {active: true});
+                        });
+                    }
+                });
             });
             break;
 

--- a/src/background.js
+++ b/src/background.js
@@ -40,7 +40,7 @@ chrome.commands.onCommand.addListener(function(command) {
             chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tab) {
                 newIndex = tab[0].index - 1;
                 if (newIndex >= 0) {
-                    chrome.tabs.query({index: newIndex}, function(btab) {
+                    chrome.tabs.query({index: newIndex, lastFocusedWindow: true}, function(btab) {
                         chrome.tabs.update(btab[0].id, {active: true});
                     });
                 } else {
@@ -53,7 +53,7 @@ chrome.commands.onCommand.addListener(function(command) {
                             }
                         });
                         // update the maximum tab index to be active
-                        chrome.tabs.query({index: maxTabIndex}, function(tabMax) {
+                        chrome.tabs.query({index: maxTabIndex, lastFocusedWindow: true}, function(tabMax) {
                             chrome.tabs.update(tabMax[0].id, {active: true});
                         });
                         maxTabIndex = 0;
@@ -70,7 +70,7 @@ chrome.commands.onCommand.addListener(function(command) {
                        chrome.tabs.update(btab[0].id, {active: true});
                     } else {
                         // last tab reached, go back to first (0-based)
-                        chrome.tabs.query({index: 0}, function(tab0) {
+                        chrome.tabs.query({index: 0, lastFocusedWindow: true}, function(tab0) {
                           chrome.tabs.update(tab0[0].id, {active: true});
                         });
                     }

--- a/src/background.js
+++ b/src/background.js
@@ -45,7 +45,7 @@ chrome.commands.onCommand.addListener(function(command) {
                     });
                 } else {
                     // first tab reached
-                    chrome.tabs.query({}, function (maxTab) {
+                    chrome.tabs.query({lastFocusedWindow: true}, function (maxTab) {
                         maxTab.forEach(function (t) {
                             // find the maximum tab index (0-based)
                             if (t.index > maxTabIndex) {
@@ -65,7 +65,7 @@ chrome.commands.onCommand.addListener(function(command) {
         case "tab_manager_browse_right":
             chrome.tabs.query({active: true, lastFocusedWindow: true}, function(tab) {
                 newIndex = tab[0].index + 1;
-                chrome.tabs.query({index: newIndex}, function(btab) {
+                chrome.tabs.query({index: newIndex, lastFocusedWindow: true}, function(btab) {
                     if (btab.length > 0) {
                        chrome.tabs.update(btab[0].id, {active: true});
                     } else {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
 
     "name": "Tab Manager Shortcuts",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "description": "Manage your chrome tabs with keyboard shortcuts.",
     "homepage_url": "https://phamdaniel.github.io",
     "icons": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
 
     "name": "Tab Manager Shortcuts",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Manage your chrome tabs with keyboard shortcuts.",
     "homepage_url": "https://phamdaniel.github.io",
     "icons": {
@@ -16,29 +16,22 @@
     },
     "commands": {
         "tab_manager_pin_current": {
-            "description": "Pin or unpin current tab.",
-            "suggested_key": {
-                "default": "Ctrl+Shift+X"
-            }
+            "description": "Pin or unpin current tab."
         },
         "tab_manager_unpin_all": {
-            "description": "Unpin all tabs in current window",
-            "suggested_key": {
-                "default": "Alt+Shift+X"
-            }
+            "description": "Unpin all tabs in current window"
         },
         "tab_manager_move_left": {
-            "description": "Move selected tab left",
-            "suggested_key": {
-                "default": "Alt+Shift+J"
-            }
+            "description": "Move selected tab left"
         },
         "tab_manager_move_right": {
-            "description": "Move selected tab right",
-            "suggested_key": {
-                "default": "Alt+Shift+K"
-            }
+            "description": "Move selected tab right"
+        },
+        "tab_manager_browse_left": {
+            "description": "Switch/browse tab left"
+        },
+        "tab_manager_browse_right": {
+            "description": "Switch/browse tab right"
         }
     }
 }
-


### PR DESCRIPTION
-Added browse functionality
-Removed default key suggestions since > 4 on initialize creates a problem
-Updated API usage to use `query()` instead of `getSelected()`

Background: I was looking for a plugin to set custom key shortcuts for moving between tabs on *nix since the defaults were not comfortable to me.  This now lets me set the browsing between tabs to Ctrl+Right Arrow and Ctrl+Left Arrow.

Tested: Fedora 25, 4.8.15-300, Chrome: 55.0.2883.87

Happy to update the Screenshot if you would like.